### PR TITLE
Fix path to tools.functions

### DIFF
--- a/_trumps.clearfix.scss
+++ b/_trumps.clearfix.scss
@@ -2,7 +2,7 @@
     #PX-CLEARFIX-DESIGN
 \*------------------------------------*/
 
-@import "../px-functions-design/tools.functions";
+@import "px-functions-design/_tools.functions.scss";
 
 @if import-once('trumps.clearfix') {
 


### PR DESCRIPTION
The relative `../` path broke all the things.
